### PR TITLE
v4.1.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,14 @@
+## Version 4.1.1 ##
+- Fixed an issue where wooden sidings and corners placed moulding blocks.
+- Fixed an issue where trying to craft mouldings together would crash the game.
+- Fixed an issue where willow and redwood sidings and mouldings rendered as the wrong subblock type. Known issue that these still render incorrectly when held by the cursor.
+- Fixed an issue where pergolas could not be crafted.
+- Fixed an issue where the recipe for dark prismarine produced the wrong result.
+- Fixed an issue where some deco blocks were not flammable (doors, workbench, hedge subblocks).
+- Fixed an issue where deco doors attempted to drop the wrong item id, leading to a crash.
+- Fixed an issue where deco logs had the same fuel value as planks, instead of being scaled up.
+- Fixed an issue where deco ladders dropped oak ladders when broken.
+
 ## Version 4.1.0 ##
 Some textures in this release have been used or modified from the following sources according to their license:
 - Oh the Biomes You'll Go

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version = 1.5.2
 yarn_mappings = 1.5.2+build.202201092137
 loader_version = 1.0.0
 
-mod_version = 4.1.0
+mod_version = 4.1.1
 maven_group = deco
 archives_base_name = Deco-Addon
 

--- a/src/main/java/deco/DecoAddon.java
+++ b/src/main/java/deco/DecoAddon.java
@@ -16,7 +16,7 @@ public class DecoAddon extends BTWAddon {
     public static boolean diamondPicksAlwaysCollectStone;
 
     private DecoAddon() {
-        super("Deco Addon", "4.1.0", "Deco");
+        super("Deco Addon", "4.1.1", "Deco");
     }
     
     @Override

--- a/src/main/java/deco/block/blocks/DecoDoorBlockWood.java
+++ b/src/main/java/deco/block/blocks/DecoDoorBlockWood.java
@@ -15,9 +15,8 @@ public class DecoDoorBlockWood extends DoorBlockWood {
 	
 	public DecoDoorBlockWood(int blockID, int itemID, String topTexture, String bottomTexture) {
 		super(blockID);
-		
-		this.itemID = itemID;
-		
+		this.setFireProperties(5, 20);
+		this.itemID = itemID + 256;
 		this.doorIconNames = new String[]{bottomTexture, topTexture};
 	}
 	

--- a/src/main/java/deco/block/blocks/DecoLadderBlock.java
+++ b/src/main/java/deco/block/blocks/DecoLadderBlock.java
@@ -8,6 +8,8 @@ import net.minecraft.src.Icon;
 import net.minecraft.src.IconRegister;
 import net.minecraft.src.World;
 
+import java.util.Random;
+
 public class DecoLadderBlock extends LadderBlock {
 	private String name;
 	
@@ -25,6 +27,11 @@ public class DecoLadderBlock extends LadderBlock {
 		int newMetadata = BTWBlocks.flamingLadder.setFacing(0, getFacing(world, x, y, z));
 		world.setBlockAndMetadataWithNotify(x, y, z, this.FLAMING_LADDER_ID, newMetadata);
 		return true;
+	}
+	
+	@Override
+	public int idDropped(int metadata, Random rand, int fortuneModifier) {
+		return this.blockID;
 	}
 	
 	//----------- Client Side Functionality -----------//

--- a/src/main/java/deco/block/blocks/DecoLadderBlockFlaming.java
+++ b/src/main/java/deco/block/blocks/DecoLadderBlockFlaming.java
@@ -7,6 +7,8 @@ import net.fabricmc.api.Environment;
 import net.minecraft.src.IconRegister;
 import net.minecraft.src.World;
 
+import java.util.Random;
+
 public class DecoLadderBlockFlaming extends LadderBlockFlaming {
 	private String name;
 	
@@ -22,6 +24,11 @@ public class DecoLadderBlockFlaming extends LadderBlockFlaming {
 	protected void extinguish(World world, int x, int y, int z) {
 		int newMetadata = BTWBlocks.ladder.setFacing(0, getFacing(world, x, y, z));
 		world.setBlockAndMetadataWithNotify(x, y, z, this.LADDER_ID, newMetadata);
+	}
+	
+	@Override
+	public int idDropped(int metadata, Random rand, int fortuneModifier) {
+		return this.LADDER_ID;
 	}
 	
 	//----------- Client Side Functionality -----------//

--- a/src/main/java/deco/block/blocks/DecoLogBlock.java
+++ b/src/main/java/deco/block/blocks/DecoLogBlock.java
@@ -71,7 +71,7 @@ public class DecoLogBlock extends LogBlock implements BlockInterface {
 
     @Override
     public int getFurnaceBurnTime(int itemDamage) {
-        return PlanksBlock.getFurnaceBurnTimeByWoodType(this.woodTypes[itemDamage & 3]);
+        return PlanksBlock.getFurnaceBurnTimeByWoodType(this.woodTypes[itemDamage & 3]) * 4;
     }
 
     @Override

--- a/src/main/java/deco/block/blocks/HedgeMouldingBlock.java
+++ b/src/main/java/deco/block/blocks/HedgeMouldingBlock.java
@@ -3,6 +3,7 @@ package deco.block.blocks;
 import btw.block.BTWBlocks;
 import btw.block.blocks.AshGroundCoverBlock;
 import btw.block.blocks.MouldingAndDecorativeWallBlock;
+import btw.block.util.Flammability;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.src.*;
@@ -22,6 +23,7 @@ public class HedgeMouldingBlock extends MouldingAndDecorativeWallBlock {
 		this.referenceBlock = referenceBlock;
 		this.referenceMetadata = referenceMetadata;
 		this.shouldColor = shouldColor;
+		this.setFireProperties(Flammability.LEAVES);
 	}
 	
 	@Override

--- a/src/main/java/deco/block/blocks/HedgeSidingAndCornerBlock.java
+++ b/src/main/java/deco/block/blocks/HedgeSidingAndCornerBlock.java
@@ -3,6 +3,7 @@ package deco.block.blocks;
 import btw.block.BTWBlocks;
 import btw.block.blocks.AshGroundCoverBlock;
 import btw.block.blocks.SidingAndCornerAndDecorativeWallBlock;
+import btw.block.util.Flammability;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.src.*;
@@ -19,6 +20,7 @@ public class HedgeSidingAndCornerBlock extends SidingAndCornerAndDecorativeWallB
 		this.referenceBlock = referenceBlock;
 		this.referenceMetadata = referenceMetadata;
 		this.shouldColor = shouldColor;
+		this.setFireProperties(Flammability.LEAVES);
 	}
 	
 	@Override

--- a/src/main/java/deco/block/blocks/WorkbenchBlock.java
+++ b/src/main/java/deco/block/blocks/WorkbenchBlock.java
@@ -1,6 +1,7 @@
 package deco.block.blocks;
 
 import btw.block.BTWBlocks;
+import btw.block.util.Flammability;
 import btw.crafting.util.FurnaceBurnTime;
 import btw.item.BTWItems;
 import net.fabricmc.api.EnvType;
@@ -13,6 +14,7 @@ public class WorkbenchBlock extends Block {
 		this.setHardness(1.5F);
 		this.setBuoyant();
 		this.setFurnaceBurnTime(FurnaceBurnTime.WOOD_BASED_BLOCK);
+		this.setFireProperties(Flammability.PLANKS);
 		this.setAxesEffectiveOn();
 		this.setStepSound(soundWoodFootstep);
 		this.setUnlocalizedName("workbench");

--- a/src/main/java/deco/block/mixins/WoodSidingAndCornerBlockMixin.java
+++ b/src/main/java/deco/block/mixins/WoodSidingAndCornerBlockMixin.java
@@ -1,7 +1,9 @@
 package deco.block.mixins;
 
+import btw.block.BTWBlocks;
 import btw.block.blocks.SidingAndCornerAndDecorativeBlock;
 import btw.block.blocks.WoodSidingAndCornerAndDecorativeBlock;
+import btw.client.render.util.RenderUtils;
 import btw.item.BTWItems;
 import btw.item.blockitems.WoodSidingDecorativeStubBlockItem;
 import deco.block.DecoBlockIDs;
@@ -9,10 +11,7 @@ import deco.block.DecoBlocks;
 import deco.block.util.WoodTypeHelper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.src.Block;
-import net.minecraft.src.Material;
-import net.minecraft.src.RenderBlocks;
-import net.minecraft.src.StepSound;
+import net.minecraft.src.*;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -59,6 +58,12 @@ public abstract class WoodSidingAndCornerBlockMixin extends SidingAndCornerAndDe
 				info.cancel();
 			}
 		}
+		else if (blockID == BTWItems.woodSidingStubID || blockID == BTWItems.woodCornerStubID) {
+			if (subtype >= WoodTypeHelper.NUM_VANILLA_WOOD) {
+				RenderUtils.renderInvBlockWithTexture(render, this, -0.5F, -0.5F, -0.5F, Block.blocksList[WoodTypeHelper.woodTypeToSidingIDMap.get(subtype)].blockIcon);
+				info.cancel();
+			}
+		}
 	}
 	
 	@Environment(EnvType.CLIENT)
@@ -77,6 +82,12 @@ public abstract class WoodSidingAndCornerBlockMixin extends SidingAndCornerAndDe
 			if (woodType >= WoodTypeHelper.NUM_VANILLA_WOOD) {
 				block = Block.blocksList[WoodTypeHelper.woodTypeToSidingIDMap.get(woodType)];
 				this.renderFenceInvBlock(render, block, SUBTYPE_FENCE);
+				info.cancel();
+			}
+		}
+		else if (blockID == BTWItems.woodSidingStubID || blockID == BTWItems.woodCornerStubID) {
+			if (subtype >= WoodTypeHelper.NUM_VANILLA_WOOD) {
+				RenderUtils.renderInvBlockWithTexture(render, this, -0.5F, -0.5F, -0.5F, Block.blocksList[WoodTypeHelper.woodTypeToSidingIDMap.get(subtype)].blockIcon);
 				info.cancel();
 			}
 		}

--- a/src/main/java/deco/block/util/WoodTypeHelper.java
+++ b/src/main/java/deco/block/util/WoodTypeHelper.java
@@ -136,7 +136,7 @@ public class WoodTypeHelper {
         woodTypeToSidingIDMap.put(woodType, sidingID);
         sidingIDToWoodTypeMap.put(sidingID, woodType);
     
-        woodTypeToSidingIDMap.put(woodType, mouldingID);
+        woodTypeToMouldingIDMap.put(woodType, mouldingID);
         mouldingIDToWoodTypeMap.put(mouldingID, woodType);
     }
     

--- a/src/main/java/deco/crafting/recipes/DecoCraftingRecipeList.java
+++ b/src/main/java/deco/crafting/recipes/DecoCraftingRecipeList.java
@@ -2911,7 +2911,7 @@ public class DecoCraftingRecipeList {
 						'P', new ItemStack(DecoBlocks.prismarine, 1, PrismarineBlock.DEFAULT_TYPE)
 				});
 		
-		RecipeManager.addRecipe(new ItemStack(DecoBlocks.prismarine, 1, PrismarineBlock.DEFAULT_TYPE),
+		RecipeManager.addRecipe(new ItemStack(DecoBlocks.prismarine, 1, PrismarineBlock.DARK_TYPE),
 				new Object[] {
 						"SSS",
 						"SDS",
@@ -2919,7 +2919,7 @@ public class DecoCraftingRecipeList {
 						'S', DecoItems.prismarineShard,
 						'D', new ItemStack(Item.dyePowder, 1, ColorUtils.BLACK.colorID)
 				});
-		RecipeManager.addRecipe(new ItemStack(DecoBlocks.prismarine, 1, PrismarineBlock.DEFAULT_TYPE),
+		RecipeManager.addRecipe(new ItemStack(DecoBlocks.prismarine, 1, PrismarineBlock.DARK_TYPE),
 				new Object[] {
 						"SSS",
 						"SDS",
@@ -4901,6 +4901,15 @@ public class DecoCraftingRecipeList {
 							new ItemStack(BTWItems.bark, WoodTypeHelper.getBarkCountForTanning(woodType), woodType)
 					});
 		}
+		
+		// General Recipes
+		RecipeManager.addRecipe(new ItemStack(DecoBlocks.pergola),
+				new Object[] {
+						" M ",
+						"M M",
+						" M ",
+						'M', new ItemStack(BTWItems.woodMouldingStubID, 1, InventoryUtils.IGNORE_METADATA)
+				});
 		
 		//------ Wood type recipes ------//
 		


### PR DESCRIPTION
- Fixed an issue where wooden sidings and corners placed moulding blocks.
- Fixed an issue where trying to craft mouldings together would crash the game.
- Fixed an issue where willow and redwood sidings and mouldings rendered as the wrong subblock type. Known issue that these still render incorrectly when held by the cursor.
- Fixed an issue where pergolas could not be crafted.
- Fixed an issue where the recipe for dark prismarine produced the wrong result.
- Fixed an issue where some deco blocks were not flammable (doors, workbench, hedge subblocks).
- Fixed an issue where deco doors attempted to drop the wrong item id, leading to a crash.
- Fixed an issue where deco logs had the same fuel value as planks, instead of being scaled up.
- Fixed an issue where deco ladders dropped oak ladders when broken.